### PR TITLE
Docs: Updated the due date to fit the plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GDG DevFest Abuja - Code Challenge
-## Due: 20th November 2018 or Earlier
+## Due: 23th November 2018 or Earlier
 
 ## Simple Unchanging Rules
 The code challenge is and will always be judged using the following criteria:


### PR DESCRIPTION
We've had participants confused with the due date, it currently reads 20th November 2018 and our agreement was the challenge to run for 3 days from the date of sharing from our end.